### PR TITLE
CSS change to fit dashboard in VR

### DIFF
--- a/src/css/desktop.css
+++ b/src/css/desktop.css
@@ -13,8 +13,9 @@ canvas {
     padding: 10px;
     background: rgba(236, 236, 236, 0.5);
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
-    justify-content: space-between;
+    justify-content: center;
 }
 /* Smartphones (portrait) ----------- */
 @media only screen and (max-width : 450px) {


### PR DESCRIPTION
Hi,

You have an amazing product here and I wanted to contribute to it. I tried it out in VR and it's great, but I couldn't see the enter VR mode in certain view width of the browser. Hopefully, this can help.

Before:

<img width="793" alt="Screen Shot 2020-07-09 at 12 45 52 PM" src="https://user-images.githubusercontent.com/14949325/87085048-11967a00-c1e4-11ea-99ab-024f642d4b0c.png">

After:
<img width="794" alt="Screen Shot 2020-07-09 at 12 46 39 PM" src="https://user-images.githubusercontent.com/14949325/87085059-152a0100-c1e4-11ea-95b6-cc81d0e247b0.png">
